### PR TITLE
add size count func, add store to file upload_all

### DIFF
--- a/RT_functions.ps1
+++ b/RT_functions.ps1
@@ -1,4 +1,4 @@
-function  Sync-Settings {
+function Sync-Settings {
     if ($nul -eq $client_url ) { return $false }
     else { return $true }
 }
@@ -89,6 +89,7 @@ function Get-TodayTraffic ( $uploads_all, $zip_size, $google_folder) {
     $uploads = $uploads_tmp
     $uploads += @{ $now = $zip_size }
     $uploads_all[$google_folder] = $uploads
+    $uploads_all | Export-Clixml -Path $upload_log_file
     return ( $uploads.values | Measure-Object -sum ).Sum, $uploads_all
 }
 
@@ -106,4 +107,8 @@ function Start-Stopping {
         Start-Sleep -Seconds 60
         Write-Output ( Get-Date -Format t )
     }
+}
+
+function Convert-Size ( $size , $base = 1024) {
+    return ( [math]::Round( $size / $base / $base / $base ) ).ToString()
 }


### PR DESCRIPTION
Добавил функцию расчёта размера файла в Гб (с базой 1024 по дефолту). Поправил код Backupper под вызов этой функции.

Добавил функционал записи массива upload_all в файл рядом. При новом запуске бекапера, история отправки на диск будет взята из файла. При желании, чтение из файла можно добавить при каждой итерации, если подразумевается запуск нескольких бекаперов одновременно (т.е считал из файла, добавил новую запись, удалил старьё за -1 сутки, записал обратно).